### PR TITLE
Remove BlueRockPools

### DIFF
--- a/v2/turtlecoin-pools.json
+++ b/v2/turtlecoin-pools.json
@@ -8,13 +8,6 @@
             "miningAddress" : "geo.atpool.party"
         },
         {
-            "name" : "BlueRockPools.net",
-            "url" : "https://trtl.bluerockpools.net/",
-            "api" : "https://trtl.bluerockpools.net:8111/",
-            "type" : "forknote-alt",
-            "miningAddress" : "trtl.bluerockpools.net"
-        },
-        {
             "name" : "CODPool",
             "url" : "https://trtl.codpool.com/",
             "api" : "https://pool1.codpool.com:8119/",


### PR DESCRIPTION
It doesn't appear that they offer a turtlecoin pool: [https://bluerockpools.net/#/home](https://bluerockpools.net/#/home)