### PR TITLE
Remove Cuveebits pool

### DIFF
--- a/v2/turtlecoin-pools.json
+++ b/v2/turtlecoin-pools.json
@@ -53,16 +53,7 @@
       "miningAddress": "trtl.cryptonote.club",
       "mergedMining": true,
       "mergedMiningIsParentChain": true
-    },
-    {
-      "name": "CuvéeARM TurtleCoin Pool",
-      "url": "https://publicnode.ydns.eu/",
-      "api": "https://publicnode.ydns.eu/api/",
-      "type": "forknote",
-      "miningAddress": "publicnode.ydns.eu",
-      "mergedMining": false,
-      "mergedMiningIsParentChain": false
-    },
+    },  
     {
       "name": "FairCryptoCoins TurtleCoin Pool",
       "url": "https://turtlepool.faircryptocoins.xyz/",


### PR DESCRIPTION
Shelved the publicnode.ydns.eu address - a pool under a new address possibly on its way soon-ish.