### PR TITLE
Remove AllCoinsPool.com

### DIFF
--- a/v2/turtlecoin-pools.json
+++ b/v2/turtlecoin-pools.json
@@ -1,15 +1,6 @@
 {
   "pools": [
     {
-      "name": "AllCoinsPool.com",
-      "url": "http://turtlecoinpool.allcoinspool.com/",
-      "api": "http://turtlecoinpool.allcoinspool.com:8117/",
-      "type": "forknote",
-      "miningAddress": "turtlecoinpool.allcoinspool.com",
-      "mergedMining": false,
-      "mergedMiningIsParentChain": false
-    },
-    {
       "name": "AtPool.party",
       "url": "https://turtle.atpool.party/",
       "api": "http://turtle-eu.atpool.party:8117/",


### PR DESCRIPTION
The pool software they run may still have some scammy code in it.

Although their [original repository](https://github.com/masterprogrammer513/cryptonote-nodejs-pool-turtlecoin-chukwa2) has been changed. I don't know if the code that's running their pool still has the old code.

This is what was [originally there.](https://github.com/TheGreatMcPain/cryptonote-nodejs-pool-turtlecoin-chukwa2/tree/6bde3c587f2270340b8b6f5852e3e6cc145795b6)

Originally it used a modified version of `cli-color-c` which was used to force a hidden fee via [lib/blockUnlocker.js.](https://github.com/TheGreatMcPain/cryptonote-nodejs-pool-turtlecoin-chukwa2/blob/6bde3c587f2270340b8b6f5852e3e6cc145795b6/lib/blockUnlocker.js#L257)